### PR TITLE
Removed month on android Card

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,12 +1,18 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Platform } from 'react-native';
 
 const Card = props => {
   let today = new Date();
   const dd = String(today.getDate()).padStart(2, '0');
   today = dd;
 
-  let month = new Date().toLocaleString('default', { month: 'short' });
+  month = "";
+
+  // As of April 2020, toLocaleDateString doesn't work on android. So for now I just removed the month from the card on android.
+  if(Platform.OS === 'ios'){
+    month = new Date().toLocaleDateString('en-US', { month: 'short' }); 
+    } else if(Platform.OS === 'android'){
+    month = null }  
 
   let time = props.time.split('T')[1];
   const hour = time.split('-')[0];


### PR DESCRIPTION
From what I could find, `toLocaleDateString` doesn't work on android. Lots of forums about it, everyone seems real mad. So for now I just removed the month from the Dashboard event card on android.